### PR TITLE
Do not require user provided `githubToken` input  (configure default)

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -23,7 +23,6 @@ jobs:
     - uses: ./
       id: filter
       with:
-        githubToken: ${{ github.token }}
         filters: |
           src:
             - src/**/*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Corresponding output variable will be created to indicate if there's a changed f
 Output variables can be later used in the `if` clause to conditionally run specific steps.
 
 ### Inputs
-- **`githubToken`**: GitHub Access Token - use `${{ github.token }}`
+- **`githubToken`**: GitHub Access Token - defaults to `${{ github.token }}`
 - **`filters`**: YAML dictionary where keys specifies rule names and values are lists of file path patterns
 
 ### Outputs
@@ -54,7 +54,6 @@ jobs:
     - uses: dorny/pr-changed-files-filter@v1
       id: filter
       with:
-        githubToken: ${{ github.token }}
         filters: |
           backend:
             - 'backend/**/*'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
     branches:
       - master

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   githubToken:
     description: 'GitHub Access Token'
     required: true
+    default: ${{ github.token }}
   filters:
     description: 'YAML dictionary where keys specifies rule names and values are lists of (globbing) file path patterns'
     required: true


### PR DESCRIPTION
Github action.yml file allows to configure inputs default value. It turns out it's possible to set default value for `githubToken` input to expression `${{ github.token }}`. This change simplifies action usage - no action is needed from end user to pass the access token.